### PR TITLE
Fix: Ensure header controls are always visible

### DIFF
--- a/index.html
+++ b/index.html
@@ -74,8 +74,11 @@
 <div class="relative flex size-full min-h-screen flex-col group/design-root overflow-x-hidden">
   <header class="sticky top-0 z-50 backdrop-blur-lg bg-[#0a1016]/80 shadow-lg no-print">
     <div class="max-w-6xl mx-auto px-6 py-4 flex justify-between items-center">
+      <!-- Group 1: Site Title/Logo -->
       <a class="text-2xl font-bold text-white hover:text-[#197fe5] transition-colors" href="#">Pablo's Portfolio</a>
-      <nav class="space-x-6 flex items-center no-print">
+
+      <!-- Group 2: Main Navigation Links -->
+      <div class="flex items-center space-x-6 no-print flex-shrink min-w-0 overflow-hidden">
         <a class="text-slate-300 hover:text-[#197fe5] transition-colors" href="#about">About</a>
         <a class="text-slate-300 hover:text-[#197fe5] transition-colors" href="#experience">Experience</a>
         <a class="text-slate-300 hover:text-[#197fe5] transition-colors" href="#projects">Projects</a>
@@ -84,14 +87,18 @@
         <a class="text-slate-300 hover:text-[#197fe5] transition-colors" href="#education">Education</a>
         <a class="text-slate-300 hover:text-[#197fe5] transition-colors" href="#certifications">Certifications</a>
         <a class="text-slate-300 hover:text-[#197fe5] transition-colors" href="#contact">Contact</a>
-        <select id="language-switcher" class="bg-[#0a1016] text-slate-300 border-slate-700 rounded-md shadow-sm focus:ring-[#197fe5] focus:border-[#197fe5] mr-4">
+      </div>
+
+      <!-- Group 3: Controls (Language Switcher & Print Button) -->
+      <div class="flex items-center space-x-4 no-print flex-shrink-0">
+        <select id="language-switcher" class="bg-[#0a1016] text-slate-300 border-slate-700 rounded-md shadow-sm focus:ring-[#197fe5] focus:border-[#197fe5]">
           <option value="es">Español</option>
           <option value="en">English</option>
         </select>
-        <button id="print-cv-button" onclick="window.print()" class="btn-hover ml-4 flex min-w-[84px] max-w-[180px] cursor-pointer items-center justify-center overflow-hidden rounded-lg h-10 px-5 bg-gradient-to-r from-[#10b981] to-[#34d399] text-white text-sm font-semibold leading-normal tracking-[0.015em] shadow-md hover:shadow-lg no-print">
+        <button id="print-cv-button" onclick="window.print()" class="btn-hover flex min-w-[84px] max-w-[180px] cursor-pointer items-center justify-center overflow-hidden rounded-lg h-10 px-5 bg-gradient-to-r from-[#10b981] to-[#34d399] text-white text-sm font-semibold leading-normal tracking-[0.015em] shadow-md hover:shadow-lg no-print">
           Print CV
         </button>
-      </nav>
+      </div>
     </div>
   </header>
 


### PR DESCRIPTION
I refactored the header HTML structure and adjusted Tailwind CSS classes to ensure the language switcher and print CV button remain persistently visible in the top-right corner, even on smaller screen widths.

Key changes:
- Header content was divided into three distinct groups:
  1. Site Title
  2. Main Navigation Links
  3. Controls (Language Switcher & Print Button)
- The 'Controls' group is set to `flex-shrink-0` to prevent it from shrinking.
- The 'Main Navigation Links' group is set to `flex-shrink min-w-0 overflow-hidden` allowing it to shrink and hide its overflowing content, thus preventing it from pushing the controls off-screen.

This addresses the issue where the language switcher and print button would become inaccessible on narrower viewports. The main navigation links will now be clipped on very small screens as a trade-off for the constant visibility of the header controls.