### PR TITLE
Fix: Hide all images in print version

### DIFF
--- a/src/input.css
+++ b/src/input.css
@@ -250,4 +250,8 @@ body {
       page-break-inside: avoid; /* Evitar que los elementos individuales se corten entre páginas */
   }
 
+  /* Ocultar todas las imágenes en la impresión */
+  img {
+    display: none !important;
+  }
 }


### PR DESCRIPTION
Added a CSS rule to `src/input.css` within the `@media print` block to set `display: none !important;` for all `img` elements. This ensures that the profile picture, project images, and any other raster images are not included in the printed version of the CV.